### PR TITLE
Fix compilation issue on rn 0.73

### DIFF
--- a/android/CMakeLists.txt
+++ b/android/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.9.0)
 
 set (PACKAGE_NAME "react-native-quick-md5")
 set (CMAKE_VERBOSE_MAKEFILE ON)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 file(TO_CMAKE_PATH "${NODE_MODULES_DIR}/react-native/ReactCommon/jsi/jsi/jsi.cpp" libPath)
 


### PR DESCRIPTION
Close: https://github.com/craftzdog/react-native-quick-md5/issues/12

This PR does is the same as [craftzdog/react-native-base64#29](https://github.com/craftzdog/react-native-quick-base64/pull/29)